### PR TITLE
Command panel

### DIFF
--- a/src/command_panel.nim
+++ b/src/command_panel.nim
@@ -1,10 +1,9 @@
-import strutils
-import typetraits
+from strutils import rsplit, parseInt, strip, find, toUpperAscii
 
-proc commandPanel*(): tuple[y: int, x: int] =
+proc renderCommandPanel*(): tuple[y: int, x: int] =
   echo "Enter Coordinate To Check(Y,X): "
   while true:
-    let yxInput = readLine(stdin)
+    let yxInput = readLine(stdin).toUpperAscii
 
     if (find(yxInput , "(") != -1 or find(yxInput , ")") != -1):
       echo "please enter only comma separated numbers"
@@ -29,10 +28,10 @@ proc commandPanel*(): tuple[y: int, x: int] =
       echo "X must be between 0 and 9"
       continue
 
+    result = (yVal - 65, xVal)
+    break
 
-    return (yVal - 65, xVal)
+when isMainModule:
 
-
-let test = commandPanel()
-
-echo "test:", test
+  let test = renderCommandPanel()
+  echo "test:", test

--- a/src/command_panel.nim
+++ b/src/command_panel.nim
@@ -5,7 +5,6 @@ proc commandPanel*(): tuple[y: int, x: int] =
   echo "Enter Coordinate To Check(Y,X): "
   while true:
     let yxInput = readLine(stdin)
-    echo "you entered: ", yxInput
 
     if (find(yxInput , "(") != -1 or find(yxInput , ")") != -1):
       echo "please enter only comma separated numbers"
@@ -18,6 +17,7 @@ proc commandPanel*(): tuple[y: int, x: int] =
       echo "please only enter two values, a letter and a number"
       continue
 
+    # fails if sepValues[1] is a non-alphanumeric character, e.g., "$,%,^"
     let yVal = int(yxInput[0])
     let xVal = parseInt(strip(sepValues[1], true))
 

--- a/src/command_panel.nim
+++ b/src/command_panel.nim
@@ -1,0 +1,38 @@
+import strutils
+import typetraits
+
+proc commandPanel*(): tuple[y: int, x: int] =
+  echo "Enter Coordinate To Check(Y,X): "
+  while true:
+    let yxInput = readLine(stdin)
+    echo "you entered: ", yxInput
+
+    if (find(yxInput , "(") != -1 or find(yxInput , ")") != -1):
+      echo "please enter only comma separated numbers"
+      continue
+
+    # should only have two values, which are numbers
+    let sepValues = rsplit(yxInput, ',')
+
+    if len(sepValues) != 2:
+      echo "please only enter two values, a letter and a number"
+      continue
+
+    let yVal = int(yxInput[0])
+    let xVal = parseInt(strip(sepValues[1], true))
+
+    if (yVal < 65 or yVal > 74):
+      echo "Y must be between A and J"
+      continue
+    
+    if (xVal < 0 or xVal > 9):
+      echo "X must be between 0 and 9"
+      continue
+
+
+    return (yVal - 65, xVal)
+
+
+let test = commandPanel()
+
+echo "test:", test


### PR DESCRIPTION
Addresses issue #7. Sets the return value of `commandPanel` to a tuple of format (int: y, int: x). Incorporates user input error handling except for non-alphanumeric characters, like "!@#$%^&*"